### PR TITLE
Modification of multibox-The operation is applied on Conv4-3

### DIFF
--- a/ssd.py
+++ b/ssd.py
@@ -163,7 +163,7 @@ def add_extras(cfg, i, batch_norm=False):
 def multibox(vgg, extra_layers, cfg, num_classes):
     loc_layers = []
     conf_layers = []
-    vgg_source = [24, -2]
+    vgg_source = [21, -2]
     for k, v in enumerate(vgg_source):
         loc_layers += [nn.Conv2d(vgg[v].out_channels,
                                  cfg[k] * 4, kernel_size=3, padding=1)]


### PR DESCRIPTION
 The first execution of 3x3 convolution filters on the feature map (classify and predict the offset to the default boxes) is applied on ``Conv4-3`` layer which is the ``21th`` element of the **vgg** list defined by the code. I think, it has been defined 24 by misatke. The ``24th`` element of the **vgg** list is the ``Conv5-1`` layer of the vgg architecture.