### PR TITLE
Fix infinity in target boxes

### DIFF
--- a/layers/box_utils.py
+++ b/layers/box_utils.py
@@ -130,7 +130,7 @@ def encode(matched, priors, variances):
     g_cxcy /= (variances[0] * priors[:, 2:])
     # match wh / prior wh
     g_wh = (matched[:, 2:] - matched[:, :2]) / priors[:, 2:]
-    g_wh = torch.log(g_wh) / variances[1]
+    g_wh = torch.log(g_wh + 1e-10) / variances[1]
     # return target for smooth_l1_loss
     return torch.cat([g_cxcy, g_wh], 1)  # [num_priors,4]
 


### PR DESCRIPTION
I got `-inf` values in my target boxes, which propagated up to the loss. I tracked down this line in `encode()` where a log is taken on the width/height of the boxes.  For some reason, some of my data-augmented boxes have zero-width (or height).

It probably happens in the data augmentation, when cropping, with boxes that are on the side of the image. One solution would be to look for zero-width/height boxes and remove them.

But I think it's a good practice to completely remove the risk of `-inf` by shifting the logarithm a tiny bit, like I do in my suggested change.

What do you think?