### PR TITLE
Solved Visdom 'win is none' issue

### DIFF
--- a/train.py
+++ b/train.py
@@ -150,12 +150,12 @@ def train():
     batch_iterator = iter(data_loader)
     for iteration in range(args.start_iter, cfg['max_iter']):
         if args.visdom and iteration != 0 and (iteration % epoch_size == 0):
+            epoch += 1
             update_vis_plot(epoch, loc_loss, conf_loss, epoch_plot, None,
                             'append', epoch_size)
             # reset epoch loss counters
             loc_loss = 0
             conf_loss = 0
-            epoch += 1
 
         if iteration in cfg['lr_steps']:
             step_index += 1


### PR DESCRIPTION
It has a issue when it met the first epoch.
when epoch is 0, the 'update_vis_plot' function mapped parameter(iteration)
and it execute if iteration == 0, and viz.line with windows2 is none