### PR TITLE
fix to ensure this works on pytorch 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+### Fixes to run on pytorch 0.4.
+pytorch 0.3.0 Legacy code has not been changed, only lines that are required to make it work on 0.4.1
+
+* line 49 of functions/detction.py
+<if scores.dim() == 0: 
+>if len(scores) == 0: 
+#torch.tensor([]).dim() retuns 1 in pytorch 0.4.1, 
+
 # SSD: Single Shot MultiBox Object Detector, in PyTorch
 A [PyTorch](http://pytorch.org/) implementation of [Single Shot MultiBox Detector](http://arxiv.org/abs/1512.02325) from the 2016 paper by Wei Liu, Dragomir Anguelov, Dumitru Erhan, Christian Szegedy, Scott Reed, Cheng-Yang, and Alexander C. Berg.  The official and original Caffe code can be found [here](https://github.com/weiliu89/caffe/tree/ssd).
 

--- a/layers/functions/detection.py
+++ b/layers/functions/detection.py
@@ -46,7 +46,7 @@ class Detect(Function):
             for cl in range(1, self.num_classes):
                 c_mask = conf_scores[cl].gt(self.conf_thresh)
                 scores = conf_scores[cl][c_mask]
-                if scores.dim() == 0:
+                if len(scores) == 0:
                     continue
                 l_mask = c_mask.unsqueeze(1).expand_as(decoded_boxes)
                 boxes = decoded_boxes[l_mask].view(-1, 4)


### PR DESCRIPTION
line 49 of detection.py / pytorch 0.4. tensor.dim() returns 1 on empty tensor