### PR TITLE
Corrected path to coco_labels

### DIFF
--- a/data/coco.py
+++ b/data/coco.py
@@ -44,7 +44,7 @@ class COCOAnnotationTransform(object):
     Initilized with a dictionary lookup of classnames to indexes
     """
     def __init__(self):
-        self.label_map = get_label_map(osp.join(COCO_ROOT, 'coco_labels.txt'))
+        self.label_map = get_label_map('data/coco_labels.txt')
 
     def __call__(self, target, width, height):
         """


### PR DESCRIPTION
`coco_labels.txt` is always stored in `./data`, not `COCO_ROOT`