### PR TITLE
ONNX export compatible with OpenCV

### DIFF
--- a/export_to_onnx.py
+++ b/export_to_onnx.py
@@ -1,0 +1,43 @@
+import argparse
+import io
+import torch
+from torch.autograd import Variable
+import onnx
+
+from ssd import build_ssd
+
+
+def assertONNXExpected(binary_pb):
+    model_def = onnx.ModelProto.FromString(binary_pb)
+    onnx.helper.strip_doc_string(model_def)
+    return model_def
+
+
+def export_to_string(model, inputs, version=None):
+    f = io.BytesIO()
+    with torch.no_grad():
+        torch.onnx.export(model, inputs, f, export_params=True, opset_version=version)
+    return f.getvalue()
+
+
+def save_model(model, input, output):
+    onnx_model_pb = export_to_string(model, input)
+    model_def = assertONNXExpected(onnx_model_pb)
+    with open(output, 'wb') as file:
+        file.write(model_def.SerializeToString())
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser('Export trained model to ONNX format')
+    parser.add_argument('--model', required=True, help='Path to saved PyTorch network weights (*.pth)')
+    parser.add_argument('--output', default='ssd.onnx', help='Name of ouput file')
+    parser.add_argument('--size', default=300, help='Input resolution')
+    parser.add_argument('--num_classes', default=21, help='Number of trained classes + 1 for background')
+    args = parser.parse_args()
+
+    net = build_ssd('export', args.size, args.num_classes)
+    net.load_state_dict(torch.load(args.model, map_location='cpu'))
+    net.eval()
+
+    input = Variable(torch.randn(1, 3, args.size, args.size))
+    save_model(net, input, args.output)

--- a/layers/functions/detection.py
+++ b/layers/functions/detection.py
@@ -10,18 +10,20 @@ class Detect(Function):
     scores and threshold to a top_k number of output predictions for both
     confidence score and locations.
     """
-    def __init__(self, num_classes, bkg_label, top_k, conf_thresh, nms_thresh):
-        self.num_classes = num_classes
-        self.background_label = bkg_label
-        self.top_k = top_k
-        # Parameters used in nms.
-        self.nms_thresh = nms_thresh
-        if nms_thresh <= 0:
-            raise ValueError('nms_threshold must be non negative.')
-        self.conf_thresh = conf_thresh
-        self.variance = cfg['variance']
+    @staticmethod
+    def symbolic(g, loc_data, conf_data, prior_data, num_classes, top_k, variance, conf_thresh, nms_thresh, phase):
+        return g.op('DetectionOutput', loc_data, conf_data, prior_data,
+                    num_classes_i=num_classes,
+                    top_k_i=top_k,
+                    keep_top_k_i=top_k,
+                    confidence_threshold_f=conf_thresh,
+                    nms_threshold_f=nms_thresh,
+                    share_location_i=1,
+                    variance_encoded_in_target_i=0,
+                    code_type_s='CENTER_SIZE',
+                    background_label_id_i=0)
 
-    def forward(self, loc_data, conf_data, prior_data):
+    def forward(self, loc_data, conf_data, prior_data, num_classes, top_k, variance, conf_thresh, nms_thresh, phase):
         """
         Args:
             loc_data: (tensor) Loc preds from loc layers
@@ -31,32 +33,39 @@ class Detect(Function):
             prior_data: (tensor) Prior boxes and variances from priorbox layers
                 Shape: [1,num_priors,4]
         """
+        loc_data = loc_data.view(loc_data.shape[0], -1, 4)
+
+        if phase == 'export':
+            prior_data = prior_data.view(-1, 4)
+            # Ignore variance from priors data
+            prior_data = prior_data[:prior_data.shape[0] // 2]
+
         num = loc_data.size(0)  # batch size
         num_priors = prior_data.size(0)
-        output = torch.zeros(num, self.num_classes, self.top_k, 5)
+        output = torch.zeros(num, num_classes, top_k, 5)
         conf_preds = conf_data.view(num, num_priors,
-                                    self.num_classes).transpose(2, 1)
+                                    num_classes).transpose(2, 1)
 
         # Decode predictions into bboxes.
         for i in range(num):
-            decoded_boxes = decode(loc_data[i], prior_data, self.variance)
+            decoded_boxes = decode(loc_data[i], prior_data, variance)
             # For each class, perform nms
             conf_scores = conf_preds[i].clone()
 
-            for cl in range(1, self.num_classes):
-                c_mask = conf_scores[cl].gt(self.conf_thresh)
+            for cl in range(1, num_classes):
+                c_mask = conf_scores[cl].gt(conf_thresh)
                 scores = conf_scores[cl][c_mask]
                 if scores.size(0) == 0:
                     continue
                 l_mask = c_mask.unsqueeze(1).expand_as(decoded_boxes)
                 boxes = decoded_boxes[l_mask].view(-1, 4)
                 # idx of highest scoring and non-overlapping boxes per class
-                ids, count = nms(boxes, scores, self.nms_thresh, self.top_k)
+                ids, count = nms(boxes, scores, nms_thresh, top_k)
                 output[i, cl, :count] = \
                     torch.cat((scores[ids[:count]].unsqueeze(1),
                                boxes[ids[:count]]), 1)
         flt = output.contiguous().view(num, -1, 5)
         _, idx = flt[:, :, 0].sort(1, descending=True)
         _, rank = idx.sort(1)
-        flt[(rank < self.top_k).unsqueeze(-1).expand_as(flt)].fill_(0)
+        flt[(rank < top_k).unsqueeze(-1).expand_as(flt)].fill_(0)
         return output

--- a/layers/modules/l2norm.py
+++ b/layers/modules/l2norm.py
@@ -20,5 +20,5 @@ class L2Norm(nn.Module):
         norm = x.pow(2).sum(dim=1, keepdim=True).sqrt()+self.eps
         #x /= norm
         x = torch.div(x,norm)
-        out = self.weight.unsqueeze(0).unsqueeze(2).unsqueeze(3).expand_as(x) * x
+        out = self.weight.view(1, -1, 1, 1) * x
         return out


### PR DESCRIPTION
This PR has changes which let to export trained model to ONNX format compatible with OpenCV (PR https://github.com/opencv/opencv/pull/16925 is required)

### Convert to ONNX
```
python3 export_to_onnx.py --model ssd300_mAP_77.43_v2.pth
```

### Run with OpenCV
```python
import numpy as np
import cv2 as cv

net = cv.dnn.readNet('ssd.onnx')

img = cv.imread('example.jpg')
rows, cols = img.shape[0:2]
inp = cv.dnn.blobFromImage(img, 1.0, (300, 300), mean=(123, 117, 104), swapRB=True)

net.setInput(inp)
out = net.forward()

for detection in out[0,0,:,:]:
    score = float(detection[2])
    if score > 0.5:
        xmin, ymin, xmax, ymax = [int(v) for v in detection[3:] * [cols, rows, cols, rows]]
        cv.rectangle(img, (xmin, ymin), (xmax, ymax), (23, 230, 210), thickness=2)

cv.imshow('Object detection', img)
cv.waitKey()
```

### Or run with OpenVINO

```
python3 /opt/intel/openvino/deployment_tools/model_optimizer/mo_onnx.py \
  --input_model ssd.onnx \
  --mean_values [123,117,104] \
  --reverse_input_channels \
  --input_shape [1,3,300,300]
```

![res](https://user-images.githubusercontent.com/25801568/77827963-d935c900-7129-11ea-8b4c-015931eb12ff.jpg)
